### PR TITLE
Url parser extensions

### DIFF
--- a/basis/urls/urls-tests.factor
+++ b/basis/urls/urls-tests.factor
@@ -124,14 +124,6 @@ CONSTANT: urls {
     }
     {
         T{ url
-            { protocol "https" }
-            { host "www.google.com" }
-            { path "/" }
-        }
-        "https://www.google.com:/"
-    }
-    {
-        T{ url
             { protocol "http" }
             { host "example.org" }
             { path "/" }
@@ -139,6 +131,16 @@ CONSTANT: urls {
             { password "" }
         }
         "http://user:@example.org/"
+    }
+    {
+        T{ url
+            { protocol "http" }
+            { host "example.org" }
+            { path "/" }
+            { username "" }
+            { password "pass" }
+        }
+        "http://:pass@example.org/"
     }
 }
 
@@ -149,6 +151,20 @@ urls [
 urls [
     swap [ 1array ] [ [ present ] curry ] bi* unit-test
 ] assoc-each
+
+{ T{ url
+    { protocol "https" }
+    { host "www.google.com" }
+    { path "/" }
+   } }
+[ "https://www.google.com:/" >url ] unit-test
+
+{ "https://www.google.com/" } 
+[ T{ url
+    { protocol "https" }
+    { host "www.google.com" }
+    { path "/" }
+} present ] unit-test
 
 { "b" } [ "a" "b" url-append-path ] unit-test
 

--- a/basis/urls/urls-tests.factor
+++ b/basis/urls/urls-tests.factor
@@ -115,6 +115,31 @@ CONSTANT: urls {
          }
         "t1000://www.google.com/"
     }
+    {
+        T{ url
+            { protocol "no-auth" }
+            { path "/some/random/path" }
+        }
+        "no-auth:/some/random/path"
+    }
+    {
+        T{ url
+            { protocol "https" }
+            { host "www.google.com" }
+            { path "/" }
+        }
+        "https://www.google.com:/"
+    }
+    {
+        T{ url
+            { protocol "http" }
+            { host "example.org" }
+            { path "/" }
+            { username "user" }
+            { password "" }
+        }
+        "http://user:@example.org/"
+    }
 }
 
 urls [

--- a/basis/urls/urls.factor
+++ b/basis/urls/urls.factor
@@ -58,7 +58,8 @@ auth     = (username (":" password  => [[ second ]])? "@"
                                     => [[ first2 2array ]])?
 
 url      = (((protocol "://") => [[ first ]] auth hostname)
-                    | (("//") => [[ f ]] auth hostname))?
+                    | (("//") => [[ f ]] auth hostname)
+                    | ((protocol ":") => [[ first V{ V{ f f } } swap prefix ]]))?
            (pathname)?
            ("?" query               => [[ second ]])?
            ("#" anchor              => [[ second ]])?

--- a/basis/urls/urls.factor
+++ b/basis/urls/urls.factor
@@ -30,10 +30,10 @@ ERROR: malformed-port ;
 : parse-host ( string -- host/f port/f )
     [
         ":" split1-last [ url-decode ]
-        [ [ f ]
-          [ string>number [ malformed-port ] unless*
-            dup 0 65535 between? [ malformed-port ] unless ]
-          if-empty ] bi*
+        [ [ f ] 
+          [ string>number [ malformed-port ] unless* ]
+          if-empty 
+        ] bi*
     ] [ f f ] if* ;
 
 GENERIC: >url ( obj -- url )

--- a/basis/urls/urls.factor
+++ b/basis/urls/urls.factor
@@ -47,7 +47,7 @@ M: url >url ;
 EBNF: parse-url [=[
 
 protocol = [a-zA-Z0-9.+-]+          => [[ url-decode ]]
-username = [^/:@#?]+                => [[ url-decode ]]
+username = [^/:@#?]*                => [[ url-decode ]]
 password = [^/:@#?]*                => [[ url-decode ]]
 pathname = [^#?]+                   => [[ url-decode ]]
 query    = [^#]+                    => [[ query>assoc ]]

--- a/basis/urls/urls.factor
+++ b/basis/urls/urls.factor
@@ -30,7 +30,10 @@ ERROR: malformed-port ;
 : parse-host ( string -- host/f port/f )
     [
         ":" split1-last [ url-decode ]
-        [ dup [ dup empty? [ drop f ] [ string>number [ malformed-port ] unless* ] if ] when ] bi*
+        [ dup [ dup empty? [ drop f ] [ string>number [
+        malformed-port ] unless* dup 65535 > over 0 < or [
+        malformed-port ]
+        when ] if ] when ] bi*
     ] [ f f ] if* ;
 
 GENERIC: >url ( obj -- url )

--- a/basis/urls/urls.factor
+++ b/basis/urls/urls.factor
@@ -59,7 +59,7 @@ auth     = (username (":" password  => [[ second ]])? "@"
 
 url      = (((protocol "://") => [[ first ]] auth hostname)
                     | (("//") => [[ f ]] auth hostname)
-                    | ((protocol ":") => [[ first V{ V{ f f } } swap prefix ]]))?
+                    | ((protocol ":") => [[ first V{ f f } V{ } 2sequence ]]))?
            (pathname)?
            ("?" query               => [[ second ]])?
            ("#" anchor              => [[ second ]])?
@@ -118,20 +118,22 @@ M: pathname >url string>> >url ;
 
 ! URL" //foo.com" takes on the protocol of the url it's derived from
 : unparse-protocol ( url -- )
-    dup protocol>> [
-        % "://" % unparse-host-part
+    protocol>> [
+        % ":" %
+    ] when* ;
+
+: unparse-authority ( url -- )
+    dup host>> [
+        "//" % unparse-host-part
     ] [
-        dup host>> [
-            "//" % unparse-host-part
-        ] [
-            drop
-        ] if
-    ] if* ;
+        drop
+    ] if ;
 
 M: url present
     [
         {
             [ unparse-protocol ]
+            [ unparse-authority ]
             [ path>> url-encode % ]
             [ query>> dup assoc-empty? [ drop ] [ "?" % assoc>query % ] if ]
             [ anchor>> [ "#" % present url-encode % ] when* ]

--- a/basis/urls/urls.factor
+++ b/basis/urls/urls.factor
@@ -30,7 +30,7 @@ ERROR: malformed-port ;
 : parse-host ( string -- host/f port/f )
     [
         ":" split1-last [ url-decode ]
-        [ dup [ string>number [ malformed-port ] unless* ] when ] bi*
+        [ dup [ dup empty? [ drop f ] [ string>number [ malformed-port ] unless* ] if ] when ] bi*
     ] [ f f ] if* ;
 
 GENERIC: >url ( obj -- url )

--- a/basis/urls/urls.factor
+++ b/basis/urls/urls.factor
@@ -5,7 +5,7 @@ USING: accessors arrays ascii assocs combinators fry
 io.pathnames io.sockets io.sockets.secure kernel lexer
 linked-assocs make math.parser multiline namespaces peg.ebnf
 present sequences splitting strings strings.parser urls.encoding
-vocabs.loader ;
+vocabs.loader math ;
 
 IN: urls
 

--- a/basis/urls/urls.factor
+++ b/basis/urls/urls.factor
@@ -45,7 +45,7 @@ EBNF: parse-url [=[
 
 protocol = [a-zA-Z0-9.+-]+          => [[ url-decode ]]
 username = [^/:@#?]+                => [[ url-decode ]]
-password = [^/:@#?]+                => [[ url-decode ]]
+password = [^/:@#?]*                => [[ url-decode ]]
 pathname = [^#?]+                   => [[ url-decode ]]
 query    = [^#]+                    => [[ query>assoc ]]
 anchor   = .+                       => [[ url-decode ]]


### PR DESCRIPTION
We extend the url parser to handle missing authorities, and empty usernames, passwords, and ports.
Also sanitychecks the range of the port and extends the prettyprinter to print urls without authorities properly.
Also added some test cases for the aforementioned extensions to the url parser.

We welcome any feedback you might have.